### PR TITLE
Add tray icon management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 
 [features]
-# tray=["tao/tray", "wry/tray"]
+tray=["tao/tray", "wry/tray"]
 
 [dependencies]
 tracing = "0.1.40"

--- a/src/mtbus.rs
+++ b/src/mtbus.rs
@@ -1,17 +1,22 @@
 use once_cell::sync::Lazy;
-use tao::window::Window;
+use tao::{event_loop::EventLoopWindowTarget, window::Window};
 use wry::WebView;
+use tao::system_tray::SystemTray;
+
+pub type MtHandler<T> = Box<
+    dyn FnOnce(&WebView, &Window, &EventLoopWindowTarget<T>, &mut Option<SystemTray>, &mut bool)
+        + Send
+        + 'static,
+>;
 
 #[allow(clippy::type_complexity)]
-static BUS: Lazy<(
-    flume::Sender<Box<dyn FnOnce(&WebView, &Window) + Send + 'static>>,
-    flume::Receiver<Box<dyn FnOnce(&WebView, &Window) + Send + 'static>>,
-)> = Lazy::new(flume::unbounded);
+static BUS: Lazy<(flume::Sender<MtHandler<()>>, flume::Receiver<MtHandler<()>>)> =
+    Lazy::new(flume::unbounded);
 
-pub fn mt_enqueue(f: impl FnOnce(&WebView, &Window) + Send + 'static) {
-    BUS.0.send(Box::new(f)).unwrap()
+pub fn mt_enqueue(f: MtHandler<()>) {
+    BUS.0.send(f).unwrap()
 }
 
-pub fn mt_next() -> impl FnOnce(&WebView, &Window) {
+pub fn mt_next() -> MtHandler<()> {
     BUS.1.recv().unwrap()
 }


### PR DESCRIPTION
## Summary
- add optional `tray` Cargo feature
- create tray management API for sending closures to GUI thread
- add `create_tray` helper and tray logic in main event loop
- update RPC methods to show/hide tray based on daemon state

## Testing
- `cargo check` *(fails: could not connect to crates.io)*